### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/android_ci.yml
+++ b/.github/workflows/android_ci.yml
@@ -9,6 +9,9 @@ on:
       - develop
       - release/*
 
+permissions:
+  contents: read
+
 jobs:
   test-feature:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/cristan/OvFietsBeschikbaarheidApp/security/code-scanning/1](https://github.com/cristan/OvFietsBeschikbaarheidApp/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will specify `contents: read`, which is sufficient for the operations performed in this workflow (e.g., checking out the repository and running tests). This change ensures that the workflow adheres to the principle of least privilege and avoids granting unnecessary permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
